### PR TITLE
Rebuild import-results periodically as well

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: Build import-results
 on:
   push:
   pull_request:
+  # Rebuild periodically to keep the artefacts fresh
+  schedule:
+  - cron: "0 1 * * 1"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Unlike resctl-demo, we were only building our own code when pushed.
However, that caused artefacts to become expired so that the issue
processing workflows could not use them anymore.

Rebuild import-results periodically as well to make sure the artefacts
are fresh.