### PR TITLE
Use new resctl-demo tag 2.1.3

### DIFF
--- a/.github/workflows/build-resctl-demo.yml
+++ b/.github/workflows/build-resctl-demo.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         version:
-          - { minor: "v2.1", ref: "v2.1.2" }
+          - { minor: "v2.1", ref: "v2.1.3" }
           - { minor: "v2.2", ref: "main" }
     steps:
       - name: Install Rust toolchain


### PR DESCRIPTION
The older resctl-demo tag 2.1.2 fails to build with latest rustc (rustc > 1.75), so use newly released tag of resctl-demo.