### PR TITLE
Keep scheduled workflows alive 

### DIFF
--- a/.github/workflows/build-resctl-demo.yml
+++ b/.github/workflows/build-resctl-demo.yml
@@ -1,9 +1,9 @@
 name: Build resctl-demo
 
 on:
-  # Every Month 01:00 to keep artifacts alive
+  # Every Monday 01:00 UTC
   schedule:
-    - cron: "0 1 1 * *"
+    - cron: "0 1 * * 1"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-resctl-demo.yml
+++ b/.github/workflows/build-resctl-demo.yml
@@ -44,3 +44,13 @@ jobs:
             ${{ format('resctl-demo-{0}/target/release/rd-hashd', matrix.version.minor) }}
             ${{ format('resctl-demo-{0}/target/release/resctl-demo', matrix.version.minor) }}
             ${{ format('resctl-demo-{0}/target/release/resctl-bench', matrix.version.minor) }}
+
+  # Keep workflow alive
+  # See https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration#disabling-and-enabling-workflows
+  workflow-keepalive:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: liskin/gh-workflow-keepalive@v1.2.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,13 @@ jobs:
           path: |
             iocost-benchmarks-ci/target/release/import-results
             iocost-benchmarks-ci/target/release/merge-results
+
+  # Keep workflow alive
+  # See https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration#disabling-and-enabling-workflows
+  workflow-keepalive:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: liskin/gh-workflow-keepalive@v1.2.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Build import-results
 on:
   push:
   pull_request:
-  # Rebuild periodically to keep the artefacts fresh
+  # Every Monday 01:00 UTC
   schedule:
     - cron: "0 1 * * 1"
   workflow_dispatch:

--- a/.github/workflows/watch-resctl-release.yml
+++ b/.github/workflows/watch-resctl-release.yml
@@ -2,7 +2,7 @@ name: Watch for resctl-demo release
 
 on:
   push:
-  # every day at 01:00
+  # Every day at 01:00
   schedule:
     - cron: "0 1 * * *"
   workflow_dispatch:

--- a/.github/workflows/watch-resctl-release.yml
+++ b/.github/workflows/watch-resctl-release.yml
@@ -32,3 +32,13 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ github.token }}
+
+  # Keep workflow alive
+  # See https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration#disabling-and-enabling-workflows
+  workflow-keepalive:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: liskin/gh-workflow-keepalive@v1.2.1


### PR DESCRIPTION
The workflows time-out after 60 days of zero activity (e.g. no commits)
and have to be manually re-enabled. Add a step to automatically enable
the scheduled workflows.