### PR TITLE
Use a specific format date when generating filename

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -270,7 +270,7 @@ impl BenchMerge {
             format!(".{}", extension)
         };
 
-        let date = chrono::offset::Utc::now();
+        let date = chrono::offset::Utc::now().format("%Y_%m_%d");
 
         let detail = match detail.into() {
             Some(d) => format!("{}-", d),


### PR DESCRIPTION
Currently we use Utc::today() to generate a timestamp for the PDF result filename which contains spaces and confuses the PDF generation in resctl-bench. Fix it by using a specific date format.