### PR TITLE
build-resctl-demo: workaround fix for resctl-demo v2.2.5 (#33)

### DIFF
--- a/.github/workflows/build-resctl-demo.yml
+++ b/.github/workflows/build-resctl-demo.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.79.0
           override: true
 
       - name: Checkout resctl-demo repository


### PR DESCRIPTION
resctl-demo v2.2.5 (crates.io) uses time v0.3.34, which fails to build on rust >= 1.8.0 (https://github.com/rust-lang/rust/issues/127343).

Fix the toolchain version to 1.79.0 until a new resctl-demo version is released.

Closes #33 