### PR TITLE
import-results: fix number of files reported in PRs

### DIFF
--- a/src/import-results.rs
+++ b/src/import-results.rs
@@ -173,7 +173,7 @@ impl HighLevel {
         HighLevel {
             version: version.to_string(),
             model_name: model_name.to_string(),
-            new_files: 1,
+            new_files: 0,
         }
     }
 


### PR DESCRIPTION
PR reports show an off-by-one number of files.

Closes #39 