### PR TITLE
import-results: use regexps and semver to parse resctl-bench version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,4 @@ serde = "1.0.137"
 serde_json = "1.0.81"
 tempfile = "3.2"
 tokio = { version = "1.17", features = ["macros", "rt-multi-thread"] }
+regex = "1.10.6"


### PR DESCRIPTION
The ad-hoc method used to parse the resctl-bench version is buggy and nonstandard.
Use more common tools for this instead.

Related to #37 