### PR TITLE
Decouple import-results from the Github workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
           path: |
             iocost-benchmarks-ci/target/release/import-results
             iocost-benchmarks-ci/target/release/merge-results
+            iocost-benchmarks-ci/config.toml
 
   # Keep workflow alive
   # See https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration#disabling-and-enabling-workflows

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,6 @@ serde_json = "1.0.81"
 tempfile = "3.2"
 tokio = { version = "1.17", features = ["macros", "rt-multi-thread"] }
 regex = "1.10.6"
+toml = "0.8.19"
+clap = { version = "4.5.18", features = ["derive"] }
+serde_with = "3.9.0"

--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,2 @@
+[config]
+database_dir = "database"

--- a/config.toml
+++ b/config.toml
@@ -1,2 +1,2 @@
 [config]
-database_dir = "database"
+#database_dir = "database"

--- a/src/import-results.rs
+++ b/src/import-results.rs
@@ -1,12 +1,15 @@
 use anyhow::{bail, Result};
 use common::{load_json, merged_file, save_pdf_to, BenchMerge};
 use git2::Index;
-use serde::Serialize;
+use serde::{Serialize, Deserialize};
+use serde_with::skip_serializing_none;
 use std::collections::HashMap;
 use std::fs;
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::process::exit;
 use semver::VersionReq;
+use clap::{Parser, Args};
 
 use crate::common::{database_directory, run_resctl, BenchVersion};
 
@@ -73,63 +76,107 @@ fn get_urls(context: &json::JsonValue) -> Result<Vec<String>> {
     Ok(urls)
 }
 
-/// Models a resctl-bench result submitted in a github issue.
+
+#[skip_serializing_none]
 #[derive(Serialize)]
 struct BenchResult {
-    issue_id: u64,
-    url: String,
-    #[serde(skip_serializing)]
-    path: String,
-    version: String,
+    /// Github issue the result is related to, if any
+    issue: Option<u64>,
+    /// Result file url, if provided through a Github issue
+    url: Option<String>,
+    /// Drive model name
     model_name: String,
+    /// Path to the result directory in the database
+    #[serde(skip_serializing)]
+    dir: String,
+    /// Path to the source result file
+    #[serde(skip_serializing)]
+    result_file: String,
+    /// resctl-bench version used to generate the result (major.minor)
+    version: String,
 }
 
 impl BenchResult {
-    /// Creates a BenchResult from a github issue id and a link to the
-    /// resctl-bench results (json file).
-    async fn new(issue_id: u64, url: String) -> Result<Self> {
-        let path = BenchResult::download_url(&url).await?;
-        let json = &load_json(&path)?[0];
-        // Data taken from the json file:
-        //  - resctl-bench version
-        //  - device model name
-        let version = {
-            let v = semver::Version::parse(
-                json["sysinfo"]["bench_version"]
-                    .to_string()
-                    .split_whitespace()
-                    .collect::<Vec<&str>>()[0],
-            )?;
-            format!("{}.{}", v.major, v.minor)
-        };
-        let model_name = json["sysinfo"]["sysreqs_report"]["scr_dev_model"]
+    /// Creates a BenchResult extracting the model and version info from
+    /// a json file (`json_result_file`) and set it to store the output
+    /// data into `database_path`
+    async fn new_from_file(json_result_file: &str, database_path: &str)
+    -> Result<Self>
+    {
+        let result = load_json(&json_result_file)
+            .expect(&format!("Error parsing json file {}", &json_result_file));
+        let full_version = result[0]["sysinfo"]["bench_version"]
             .to_string()
             .split_whitespace()
-            .collect::<Vec<&str>>()
-            .join("_");
+            .collect::<Vec<_>>()[0]
+            .to_string();
+        let version = {
+            let v = semver::Version::parse(&full_version)?;
+            format!("{}.{}", v.major, v.minor)
+        };
+        semver::Version::parse(&full_version)?;
+        let model_name = result[0]["sysinfo"]["sysreqs_report"]["scr_dev_model"]
+            .to_string()
+            .replace(" ", "_");
+        let dir = PathBuf::from(database_path)
+            .join(&version)
+            .join(&model_name)
+            .into_os_string()
+            .into_string().unwrap();
         Ok(BenchResult {
-            issue_id,
-            url,
-            path,
-            version,
+            issue: None,
+            url: None,
             model_name,
+            dir,
+            result_file: json_result_file.to_string(),
+            version
         })
     }
 
-    /// Downloads a file and saves it into a gzipped file with a unique
-    /// name based on the file contents.
+    /// Creates a BenchResult extracting the model and version info from
+    /// a remote json file (`url`), associating it to a Github `issue`
+    /// and setting it to store the output
+    /// data into `database_path`
+    async fn new_from_issue(issue: u64, url: &str, database_path: &str)
+    -> Result<Self>
+    {
+        let path = BenchResult::download_url(&url).await?;
+        let json = &load_json(&path)?[0];
+        let full_version = json[0]["sysinfo"]["bench_version"]
+            .to_string()
+            .split_whitespace()
+            .collect::<Vec<_>>()[0]
+            .to_string();
+        let version = {
+            let v = semver::Version::parse(&full_version)?;
+            format!("{}.{}", v.major, v.minor)
+        };
+        semver::Version::parse(&full_version)?;
+        let model_name = json[0]["sysinfo"]["sysreqs_report"]["scr_dev_model"]
+            .to_string()
+            .replace(" ", "_");
+        let dir = PathBuf::from(database_path)
+            .join(&version)
+            .join(&model_name)
+            .into_os_string()
+            .into_string().unwrap();
+        Ok(BenchResult {
+            issue: Some(issue),
+            url: Some(String::from(url)),
+            model_name,
+            dir,
+            result_file: path,
+            version
+        })
+    }
+
     async fn download_url(url: &str) -> Result<String> {
         let response = reqwest::get(url).await?;
-
         let contents = response.bytes().await?;
-
-        // Use md5sum of the data as filename, we only care about exact
-        // duplicates.
+        // Use md5sum of the data as filename, we only care about exact duplicates.
         let path = format!("result-{:x}.json.gz", md5::compute(&contents));
-
         let mut file = fs::File::create(&path)?;
         file.write_all(&contents)?;
-
         Ok(path)
     }
 
@@ -137,45 +184,58 @@ impl BenchResult {
     fn validate(&self) -> Result<()> {
         run_resctl(
             &self.version,
-            &["--result", "/tmp/result.json", "merge", &self.path],
-        )
-        .map(|_| ())
-    }
-
-    /// Stores the results file, together with a metadata file, in the
-    /// appropriate directory in the repo pointed by index, creating the
-    /// directories if needed.
-    ///
-    /// The metadata file is just the json-serialized output of `self`
-    /// (BenchResult).
-    fn add_to_database(&self, index: &mut Index) -> Result<()> {
-        // Save PDF for artifact.
-        let pdfs_dir = PathBuf::from(".").join(&format!("pdfs-for-{}", self.issue_id));
-        save_pdf_to(&self.version, &PathBuf::from(&self.path), &pdfs_dir, None)?;
-
-        let model_directory = database_directory(&self.version, &self.model_name);
-        fs::create_dir_all(&model_directory).ok();
-
-        let database_file = model_directory.join(&self.path);
-        fs::rename(&self.path, &database_file)?;
-
-        index.add_path(&database_file)?;
-
-        let mut metadata_path = database_file;
-        metadata_path.set_extension("metadata");
-
-        let mut metadata = fs::File::create(&metadata_path)?;
-        write!(metadata, "{}", serde_json::to_string(self)?)?;
-
-        index.add_path(&metadata_path)?;
-
+            &["--result", "/tmp/result.json", "merge", &self.result_file],
+        )?;
         Ok(())
     }
 
-    /// Provides a unique identifier for a BenchResult, suitable as a
-    /// hash table key.
-    fn merge_id(&self) -> String {
-        format!("{}-{}", self.version, self.model_name)
+    /// Stores the results file, together with a metadata file and the
+    /// pdf output, in the appropriate directory in the repo pointed by
+    /// index, creating the directories if needed.
+    ///
+    /// If an `id` string is specified, it's used as a suffix for some
+    /// of the generated directories and files
+    ///
+    /// The metadata file is just the json-serialized output of `self`
+    /// (BenchResult).
+    fn add_to_database(&self, id: Option<&str>, repo_index: Option<&mut Index>) -> Result<()> {
+        // NOTE: the result file is expected to have extension .json.gz
+        let basename = Path::new(&self.result_file)
+            .with_extension("")
+            .with_extension("")
+            .to_str()
+            .unwrap()
+            .to_string();
+        let pdfs_dir = match id {
+            Some(id) => PathBuf::from(".")
+                .join(&format!("pdfs-for-{}", id)),
+            None => {
+                if let Some(issue) = &self.issue {
+                    PathBuf::from(".")
+                        .join(&format!("pdfs-for-{}", issue))
+                } else {
+                    PathBuf::from(".")
+                        .join(&format!("pdfs-for-{}-{}", &self.model_name, &self.version))
+                }
+            }
+        };
+        save_pdf_to(&self.version, &PathBuf::from(&self.result_file), &pdfs_dir, None)?;
+        // Generate DB directory and place the result file there
+        fs::create_dir_all(&self.dir).ok();
+        let db_file = PathBuf::from(&self.dir).join(&self.result_file);
+        fs::rename(&self.result_file, &db_file)?;
+        // Create metadata file and save it in the DB dir
+        let mut metadata_filepath = PathBuf::from(&self.dir).join(basename);
+        metadata_filepath.set_extension("json.metadata");
+        let mut metadata_file = fs::File::create(&metadata_filepath)?;
+        write!(metadata_file, "{}", serde_json::to_string(self)?)?;
+
+        // Add new files to repo index, if specified
+        if let Some(index) = repo_index {
+            index.add_path(&db_file)?;
+            index.add_path(&metadata_filepath)?;
+        }
+        Ok(())
     }
 }
 
@@ -234,31 +294,35 @@ impl HighLevel {
     }
 }
 
-#[tokio::main]
-async fn main() -> Result<()> {
-    let context = json::parse(&std::env::var("GITHUB_CONTEXT")?)?;
+async fn run_as_gh_workflow(envvar: &str, database_path: &str) -> Result<()>{
+    let context = json::parse(&std::env::var(envvar)?)?;
     let issue_id = context["event"]["issue"]["number"].as_u64().unwrap();
     let git_repo = git2::Repository::open(".")?;
     let mut index = git_repo.index()?;
+    // HashMap to keep the complete set of results
     let mut merged = HashMap::new();
-    let mut errors = vec![];
 
     // Download and validate all provided URLs.
-    for url in get_urls(&context)? {
-        let bench_result = BenchResult::new(issue_id, url).await?;
+    let urls = get_urls(&context)?;
+    let mut errors = vec![];
+    for url in urls {
+        let bench_result = BenchResult::new_from_issue(
+            issue_id,
+            &url,
+            database_path).await?;
         if let Err(e) = bench_result.validate() {
-            errors.push(format!(
-                "= File {} failed validation: =\n\n{}",
-                bench_result.url, e
-            ));
+            errors.push(
+                format!("File {} failed validation: \n\n{}", url, e)
+            );
             continue;
         }
-        bench_result.add_to_database(&mut index)?;
+        bench_result.add_to_database(None, Some(&mut index))?;
         merged
-            .entry(bench_result.merge_id())
+            .entry(format!("{}-{}", &bench_result.version, &bench_result.model_name))
             .or_insert_with(|| HighLevel::new(&bench_result.version, &bench_result.model_name))
             .increment();
     }
+
     if !errors.is_empty() {
         octocrab::OctocrabBuilder::new()
             .personal_token(context["token"].as_str().unwrap().to_string())
@@ -278,6 +342,8 @@ async fn main() -> Result<()> {
     // Commit the new and changed files.
     let sig = git2::Signature::now("iocost bot", "iocost-bot@has.no.email")?;
     let parent_commit = git_repo.head()?.peel_to_commit()?;
+    let oid = index.write_tree()?;
+    let tree = git_repo.find_tree(oid)?;
     let description = format!(
         "Closes #{}\n\n{}",
         issue_id,
@@ -293,15 +359,14 @@ async fn main() -> Result<()> {
             .collect::<Vec<String>>()
             .join("\n")
     );
+    let commit_title = format!("Automated update from issue {}", issue_id);
+    let commit_message = format!("{commit_title}\n\n{description}");
     let commit = git_repo.commit(
         Some("HEAD"),
         &sig,
         &sig,
-        // Commit message
-        &format!("Automated update from issue {}\n\n{}",
-            issue_id,
-            description),
-        &git_repo.find_tree(index.write_tree()?)?,
+        &commit_message,
+        &tree,
         &[&parent_commit],
     )?;
     let branch_name = format!("iocost-bot/{}", issue_id);
@@ -309,4 +374,77 @@ async fn main() -> Result<()> {
 
     // The rest of the process happens in the workflow.
     Ok(())
+}
+
+
+/// Top-level struct to parse the config toml file
+#[derive(Debug, Deserialize)]
+struct TomlData {
+    config: Config,
+}
+
+/// Struct to parse the [config] section of the config toml file
+#[derive(Debug, Deserialize)]
+struct Config {
+    database_dir: String,
+}
+
+#[derive(Parser, Debug)]
+#[command(version, about)]
+/// Imports resctl-bench results into a common database
+struct Cli {
+    /// Path of the toml config file to load
+    #[arg(short, long, value_name = "FILE", default_value = "config.toml")]
+    config_file: Option<String>,
+
+    #[command(flatten)]
+    input: Input,
+}
+
+#[derive(Args, Debug)]
+#[group(required = true, multiple = false)]
+struct Input {
+    /// Run as part of a Github workflow and load the context from this envvar
+    #[arg(short, long, value_name = "envvar", default_value = "GITHUB_CONTEXT")]
+    gh_workflow: Option<String>,
+
+    /// Result file to process
+    #[arg(short, long, value_name = "FILE.json.gz")]
+    result: Option<String>,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let args = Cli::parse();
+    println!("args: {:?}", args);
+
+    // Load config from toml file
+    let config_file_path = args.config_file.unwrap();
+    let config: TomlData = match fs::read_to_string(&config_file_path) {
+        Ok(contents) => {
+            toml::from_str(&contents)
+                .expect(&format!("Error parsing toml file {}", config_file_path))
+        },
+        Err(_) => {
+            eprintln!("Can't open config file: {}", config_file_path);
+            exit(1);
+        }
+    };
+
+    if let Some(result_file) = args.input.result {
+        // Run with result file as input
+        let bench_result = BenchResult::new_from_file(
+            &result_file,
+            &config.config.database_dir).await?;
+        bench_result.validate()
+            .expect(&format!("File {} failed validation", &result_file));
+        bench_result.add_to_database(None, None)?;
+    } else {
+        // Run as part of a Github workflow
+        run_as_gh_workflow(
+            &args.input.gh_workflow.unwrap(),
+            &config.config.database_dir).await?;
+    }
+
+    exit(1);
 }


### PR DESCRIPTION
Allow the tool to run on the usual github workflow by default, but add config and command line options to run it standalone.