### PR TITLE
Allow merge-results to pick any json.gz file in the database

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -205,7 +205,7 @@ impl BenchMerge {
 
     fn result_paths_for(directory: &Path) -> Result<Vec<PathBuf>> {
         Ok(
-            glob(&format!("{}/result-*.json.gz", directory.to_string_lossy()))
+            glob(&format!("{}/*.json.gz", directory.to_string_lossy()))
                 .unwrap()
                 .flatten()
                 .collect(),


### PR DESCRIPTION
Remove the restriction for benchmark result files to be named "result-*.json.gz". Pick up any file in the database that has a .json.gz prefix instead. This will make merge-results automatically pick up files generated by resctl-bench without the need to manually rename them.
