### PR TITLE
import-results: add additional allowed prefix

### DIFF
--- a/src/import-results.rs
+++ b/src/import-results.rs
@@ -17,6 +17,7 @@ mod common;
 static ALLOWED_PREFIXES: &[&str] = &[
     "https://github.com/",
     "https://iocost-submit-us-east-1.s3.us-east-1.amazonaws.com/",
+    "https://iocost-submit-eu-north-1.s3.eu-north-1.amazonaws.com/",
 ];
 static GH_CONTEXT_ENVVAR: &str = "GITHUB_CONTEXT";
 


### PR DESCRIPTION
Allow to download results file from an additional S3 location.